### PR TITLE
fix: remove irrelevant workflow triggers

### DIFF
--- a/.github/workflows/pr-title-lint.yaml
+++ b/.github/workflows/pr-title-lint.yaml
@@ -1,9 +1,6 @@
 name: PR Title Lint
 
 on:
-  push:
-    branches:
-      - 'main'
   pull_request:
     branches:
       - 'main'
@@ -14,7 +11,6 @@ on:
     types:
       - opened
       - edited
-  workflow_dispatch:
 
 jobs:
   pr-title-lint:

--- a/.github/workflows/pr-title-lint.yaml
+++ b/.github/workflows/pr-title-lint.yaml
@@ -7,10 +7,6 @@ on:
     types:
       - opened
       - edited
-  pull_request_target:
-    types:
-      - opened
-      - edited
 
 jobs:
   pr-title-lint:


### PR DESCRIPTION
`push` & `workflow_dispatch` don't work with the action integration.
Also removing pull_request_target because it is unnecessary and redundant (workflow runs twice)